### PR TITLE
Store hide back button on update

### DIFF
--- a/Classes/MMSnapHeaderView.h
+++ b/Classes/MMSnapHeaderView.h
@@ -43,11 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL hidesBackButton;
 
 /**
- *  A Boolean value that determines whether the back button is available.
- */
-@property (assign, nonatomic) BOOL backActionAvailable;
-
-/**
  *  A Boolean value indicating whether the title should be displayed in a large format.
  */
 @property (assign, nonatomic) BOOL displaysLargeTitle;

--- a/Classes/MMSnapHeaderView.m
+++ b/Classes/MMSnapHeaderView.m
@@ -31,6 +31,7 @@
 
 @property (strong, nonatomic) UIButton *regularBackButton;
 @property (strong, nonatomic) UIButton *compactBackButton;
+@property (assign, nonatomic) BOOL backActionAvailable;
 
 @property (readonly, nonatomic) BOOL pagingEnabled;
 @property (assign, nonatomic) BOOL rotatesBackButton;
@@ -230,7 +231,6 @@
 
 - (void)_backButtonTouchUpInside:(id)sender
 {
-    if(!self.backActionAvailable) { return; }
     MMSplitViewController *snapController = self.splitViewController;
     UIViewController *viewController = self.viewController;
     
@@ -684,6 +684,7 @@
 - (void)setHidesBackButton:(BOOL)hidesBackButton
 {
     if (hidesBackButton != self.hidesBackButton) {
+        _hidesBackButton = hidesBackButton;
         [self setNeedsLayout];
     }
 }


### PR DESCRIPTION
### What does this PR do? 

Store hide back button on update

### Clubhouse tickets 
[[ch88957]](https://app.clubhouse.io/cornershop-customers/story/88957/stores-list-disappears-when-user-clicks-on-in-landscape-mode)

### linked PR
[[Cornershop PR]](https://github.com/cornershop/cornershop-ios/pull/1249)

### Screenshots/Recordings (if appropriate)

| Before | After |
| :---------:| -------- |
| ![Simulator Screen Shot - iPhone Xʀ - 2021-08-26 at 10 35 16](https://user-images.githubusercontent.com/32248030/130982551-f42ae401-c70e-43ac-9854-59fbc97a14c2.png) | ![Simulator Screen Recording - iPhone Xʀ - 2021-08-26 at 10 34 22](https://user-images.githubusercontent.com/32248030/130982575-d95c6ee9-1167-4ede-9fbf-5ff798728540.gif) |
