### PR TITLE
[SWAT] Fix button spacing in `displaysLargeTitleWithSize`

### DIFF
--- a/Classes/MMSnapHeaderView.m
+++ b/Classes/MMSnapHeaderView.m
@@ -71,7 +71,7 @@
         _regularHeight = self.class._UINavigationBarDefaultHeight;
         _largeHeaderHeight = 52.0f;
         _backButtonSpacing = 8.0f;
-        _barButtonSpacing = 16.0f;
+        _barButtonSpacing = 8.0f;
         _interSpacing = 5.0;
         _largeHeaderScaleFactor = 1.0f;
         
@@ -277,7 +277,8 @@
     BOOL usesCustomTitleView = _titleView != nil;
     
     UIEdgeInsets barButtonsInsets = (UIEdgeInsets){
-        .left = (showsBackButton ? backEdgeSpacing : edgeSpacing), .right = edgeSpacing
+        .left = (showsBackButton ? backEdgeSpacing : edgeSpacing),
+        .right = edgeSpacing
     };
     
     UIEdgeInsets contentInset = UIEdgeInsetsZero;
@@ -800,7 +801,7 @@
 - (BOOL)displaysLargeTitleWithSize:(CGSize)size
 {
     if (self.displaysLargeTitle) {
-        const CGFloat spacing = _barButtonSpacing;
+        const CGFloat spacing = [self.class _UINavigationBarDoubleEdgesRequired] ? [self.class _UINavigationBarDoubleEdgesSpacing] :  _barButtonSpacing;
         const CGFloat allowedWidth = size.width - (spacing * 2.0f);
         
         if (_largeTitleSize.width > allowedWidth) {

--- a/Classes/MMSnapHeaderView.m
+++ b/Classes/MMSnapHeaderView.m
@@ -71,7 +71,7 @@
         _regularHeight = self.class._UINavigationBarDefaultHeight;
         _largeHeaderHeight = 52.0f;
         _backButtonSpacing = 8.0f;
-        _barButtonSpacing = 8.0f;
+        _barButtonSpacing = 16.0f;
         _interSpacing = 5.0;
         _largeHeaderScaleFactor = 1.0f;
         


### PR DESCRIPTION
### What does this PR do?
Check if double edges are required in `displaysLargeTitleWithSize` and set `spacing` accordingly to calculate if the large title is in the allowed width.

### Why?
In the `displaysLargeTitleWithSize` method the allowedWidth is calculated using this property that is always set to `8.0f`, but in `layoutSubviews` the `edgeSpacing` variable is set to `16.0f` for iOS 10+. Depending on the title width the label was set to display in inline mode but the navbar was set to display large title leaving a blank space between the title and the search bar.