### PR TITLE
[SWAT] Add maximumScale to title width calculation

### DIFF
--- a/Classes/MMSnapHeaderView.m
+++ b/Classes/MMSnapHeaderView.m
@@ -56,6 +56,9 @@
 
 @implementation MMSnapHeaderView
 
+static const CGFloat headerScaleDelta = 0.1f;
+static const CGFloat maximumScale = 1.0f + headerScaleDelta;
+
 #define UIKitLocalizedString(key) [[NSBundle bundleWithIdentifier:@"com.apple.UIKit"] localizedStringForKey:key value:@"" table:nil]
 
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v) \
@@ -414,9 +417,6 @@
     
     // Large heading.
     if ([self.class _UINavigationBarUsesLargeTitles]) {
-        static const CGFloat headerScaleDelta = 0.1f;
-        static const CGFloat maximumScale = 1.0f + headerScaleDelta;
-        
         CGRect largeContentRect = UIEdgeInsetsInsetRect(bounds, (UIEdgeInsets){ .left = edgeSpacing, .right = edgeSpacing });
         
         const CGFloat regularHeight = _regularHeight;
@@ -804,7 +804,7 @@
         const CGFloat spacing = [self.class _UINavigationBarDoubleEdgesRequired] ? [self.class _UINavigationBarDoubleEdgesSpacing] :  _barButtonSpacing;
         const CGFloat allowedWidth = size.width - (spacing * 2.0f);
         
-        if (_largeTitleSize.width > allowedWidth) {
+        if ((_largeTitleSize.width * maximumScale) > allowedWidth) {
             return NO;
         }
         

--- a/MMSplitViewController.podspec
+++ b/MMSplitViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MMSplitViewController"
-  s.version      = "0.0.11"
+  s.version      = "0.0.12"
   s.summary      = "An interactive split interface."
   s.homepage     = "https://matias.ma/"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
The maximumScale is used to calculate if large titles should be displayed in `layoutSubviews` so it is needed to add it to `displaysLargeTitleWithSize` to prevent that the title is displayed inline and the navbar has extra height.